### PR TITLE
Update macro-GSbrewer-pay_arche.txt

### DIFF
--- a/macros/GStrader/macro-GSbrewer-pay_arche.txt
+++ b/macros/GStrader/macro-GSbrewer-pay_arche.txt
@@ -525,7 +525,8 @@ do c @gstorage
 pause 1
 
 :repeatCP
- if ($.sp < 100) goto endBrew
+if ($.sp < 100) goto endBrew
+if ( @storamount($item) > 29000 ) goto endCP 
 
 if ( @storamount($iBowl) < 1 ) goto endCP 
   do storage get $iBowl 100


### PR DESCRIPTION
Fix: The alchemist does not start brewing a potion if there are more than 29,000 of them in the storage